### PR TITLE
fix capability not found

### DIFF
--- a/classes/local/hooks/output/before_http_headers.php
+++ b/classes/local/hooks/output/before_http_headers.php
@@ -15,7 +15,8 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace local_h5pcaretaker\local\hooks\output;
-use action_link, context_system, moodle_url, navigation_node;
+
+use action_link, context_system, core_plugin_manager, moodle_url, navigation_node;
 
 /**
  * Hook for before http headers.
@@ -42,7 +43,10 @@ class before_http_headers {
         global $PAGE;
 
         $context = context_system::instance();
-        if (!has_capability('local/h5pcaretaker:use', $context)) {
+        $pluginmanager = core_plugin_manager::instance();
+        $plugininfo = $pluginmanager->get_plugin_info('local_h5pcaretaker');
+
+        if (!$plugininfo->is_installed_and_upgraded() || !has_capability('local/h5pcaretaker:use', $context)) {
             return;
         }
 


### PR DESCRIPTION
With the debug mode on, the Moodle installer returns an error, because of the capacity check performed in the class `before_http_headers`:

```
Capability "local/h5pcaretaker:use" was not found! This has to be fixed in code.

    line 458 of /lib/accesslib.php: call to debugging()
    line 45 of /local/h5pcaretaker/classes/local/hooks/output/before_http_headers.php: call to has_capability()
    line 35 of /local/h5pcaretaker/classes/local/hooks/output/before_http_headers.php: call to local_h5pcaretaker\local\hooks\output\before_http_headers::add_caretaker_link()
    line ? of unknownfile: call to local_h5pcaretaker\local\hooks\output\before_http_headers::callback()
    line 299 of /lib/classes/hook/manager.php: call to call_user_func()
    line 1379 of /lib/outputrenderers.php: call to core\hook\manager->dispatch()
    line 564 of /lib/outputrenderers.php: call to core_renderer->header()
    line 162 of /admin/renderer.php: call to plugin_renderer_base->__call()
    line 574 of /admin/index.php: call to core_admin_renderer->upgrade_environment_page()
```

This was tested on versions 4.4 and 4.5.

The plugin manager's function `is_installed_and_upgraded()` seems like a good solution in combination with the capability check on `'local/h5pcaretaker:use'`. It is usable since Moodle 2.6.11+ (Build: 20150619).
