### PR TITLE
fix non-sequential array keys in locales

### DIFF
--- a/classes/render.php
+++ b/classes/render.php
@@ -115,6 +115,6 @@ class render {
             ];
         }, $availablelocales);
 
-        return $OUTPUT->render_from_template('local_h5pcaretaker/select_language', ['locales' => $locales]);
+        return $OUTPUT->render_from_template('local_h5pcaretaker/select_language', ['locales' => array_values($locales)]);
     }
 }


### PR DESCRIPTION
Hi, after installing the plugin, it turns out that the language selector isn't filled with locales due to gaps in the array keys provided to the templates:

```php
return $OUTPUT->render_from_template('local_h5pcaretaker/select_language', ['locales' => $locales]);
```

Here, depending on the language packs available, `$locales` may have non-sequential array keys, messing up with the Mustache template. For example in my case:

```
Array
(
    [0] => Array
        (
            [locale] => en
            [name] => English
            [selected] => 1
        )

    [2] => Array
        (
            [locale] => fr
            [name] => français
            [selected] => 
        )
)
```
